### PR TITLE
fixed bug

### DIFF
--- a/src/addEvent.js
+++ b/src/addEvent.js
@@ -3,7 +3,14 @@ const dynamo = new AWS.DynamoDB.DocumentClient({ convertEmptyValues: true });
 
 const tableName = 'InternalEvents';
 
-const generateId = () => Date.now().toString();
+const generateId = () =>
+  [...Array(8)]
+    .map(() =>
+      Math.random()
+        .toString(36)
+        .slice(-8),
+    )
+    .join('');
 
 const params = event => ({
   TableName: tableName,
@@ -11,14 +18,18 @@ const params = event => ({
 });
 
 const put = params =>
-  dynamo.put(params, (err, data) => {
+  dynamo.put(params, function(err, data) {
     console.log({ data }, { err });
   });
 
 async function main(event) {
-  const { response } = await put(params(event));
-  console.log(response.error);
-  return { result: response.error || 'OK' };
+  try {
+    const response = await put(params(event)).promise();
+    return { result: 'OK' };
+  } catch (e) {
+    console.log(e);
+    return { result: e };
+  }
 }
 
 module.exports = main;


### PR DESCRIPTION
### 背景

- ローカルだと動くのにLambdaからだとDynamoにデータ登録できなかった

### 何が起きてたか

- dynamo.putの戻り値はPromiseじゃない
- だから`.promise()`つけないと当然awaitされずに処理が進む
- ローカルなら非同期で終わるまで実行されてたけどLambdaだとreturnしてプロセスが終わってしまう(Dynamoに書き込み終わる前に)

```js
const response = await put(params(event)).promise();
```